### PR TITLE
snapcraft.yaml: Update metainfo path

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,4 @@
 name: gnome-mahjongg
-version: git
 adopt-info: gnome-mahjongg
 summary: Match tiles and clear the board
 description: |
@@ -44,7 +43,7 @@ parts:
     source-type: git
     source-tag: '47.0'
     source-depth: 1
-    parse-info: [usr/share/metainfo/org.gnome.Mahjongg.appdata.xml]
+    parse-info: [usr/share/metainfo/org.gnome.Mahjongg.metainfo.xml]
     override-build: |
       sed -i -e 's|=org.gnome.Mahjongg$|=${SNAP}/meta/gui/org.gnome.Mahjongg.svg|g' $CRAFT_PART_SRC/data/org.gnome.Mahjongg.desktop.in.in
       craftctl default


### PR DESCRIPTION
# Pull Request Template

## Description

The path to the metainfo file changed in Mahjongg 47.

Closes #10 

## Type of change

Please check only the options that are relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Built with `snapcraft`, confirmed that the correct version number is extracted from the metainfo file.

**Test Configuration**:

* OS (please include version): Ubuntu 22.04
* Any other relevant environment information:

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any misspellings

